### PR TITLE
fixes #9: correct call of temlate part in template page_fullwidth.php

### DIFF
--- a/page-templates/page_fullwidth.php
+++ b/page-templates/page_fullwidth.php
@@ -14,7 +14,7 @@ Template Name: Full width
 
 			<?php while ( have_posts() ) : the_post(); ?>
 
-				<?php get_template_part( 'content', 'page' ); ?>
+				<?php get_template_part( 'template-parts/content', 'page' ); ?>
 
 				<?php
 
@@ -35,4 +35,3 @@ Template Name: Full width
 	</div><!-- #primary -->
 
 <?php get_footer(); ?>
-


### PR DESCRIPTION
According to Function Reference, to use `get_template_part()` with subfolders in your theme directory, the folder name should be prepended before the slug. Fixes #9 .